### PR TITLE
Fix Audi find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(DCGP_BUILD_DCGP)
     message(STATUS "MPFR version is ok.")
 
     # Audi setup
-    find_package(audi REQUIRED)
+    find_package(Audi REQUIRED)
     message(STATUS "AUDI header only library found.")
     message(STATUS "AUDI include dir is: ${AUDI_INCLUDE_DIRS}")
 


### PR DESCRIPTION
Because the file to be loaded is called `/cmake_modules/FindAudi.cmake` the `find_package` statement should say `Audi` instead of `audi`. See [the `find_package` documentation](https://cmake.org/cmake/help/v3.0/command/find_package.html).

An other solution could be to rename `FindAudi.cmake` to `Findaudi.cmake`.