### PR TITLE
Remove protected division for gdual types

### DIFF
--- a/include/dcgp/kernel.hpp
+++ b/include/dcgp/kernel.hpp
@@ -1,7 +1,6 @@
 #ifndef DCGP_KERNEL_H
 #define DCGP_KERNEL_H
 
-#include <audi/gdual.hpp>
 #include <functional> // std::function
 #include <iostream>
 #include <string>
@@ -9,9 +8,6 @@
 #include <vector>
 
 #include <dcgp/config.hpp>
-
-using namespace audi;
-using gdual_d = audi::gdual<double>;
 
 namespace dcgp
 {

--- a/include/dcgp/kernel_set.hpp
+++ b/include/dcgp/kernel_set.hpp
@@ -1,7 +1,7 @@
 #ifndef DCGP_kernel_set_H
 #define DCGP_kernel_set_H
 
-#include <audi/gdual.hpp>
+#include <type_traits>
 #include <vector>
 
 #include <dcgp/config.hpp>
@@ -61,7 +61,8 @@ public:
             m_kernels.emplace_back(my_mul<T>, print_my_mul, kernel_name);
         else if (kernel_name == "div")
             m_kernels.emplace_back(my_div<T>, print_my_div, kernel_name);
-        else if (kernel_name == "pdiv")
+        //  pdiv is only available when class type is double
+        else if (kernel_name == "pdiv" && std::is_same<T, double>::value)
             m_kernels.emplace_back(my_pdiv<T>, print_my_pdiv, kernel_name);
         else if (kernel_name == "sig")
             m_kernels.emplace_back(my_sig<T>, print_my_sig, kernel_name);

--- a/include/dcgp/kernel_set.hpp
+++ b/include/dcgp/kernel_set.hpp
@@ -1,6 +1,7 @@
 #ifndef DCGP_kernel_set_H
 #define DCGP_kernel_set_H
 
+#include <audi/audi.hpp>
 #include <type_traits>
 #include <vector>
 
@@ -126,7 +127,7 @@ public:
      */
     friend std::ostream &operator<<(std::ostream &os, const kernel_set<T> &d)
     {
-        stream(os, d());
+        audi::stream(os, d());
         return os;
     }
 

--- a/include/dcgp/type_traits.hpp
+++ b/include/dcgp/type_traits.hpp
@@ -1,6 +1,8 @@
 #ifndef DCGP_TYPE_TRAITS_H
 #define DCGP_TYPE_TRAITS_H
 
+#include <audi/gdual.hpp>
+
 #include <dcgp/config.hpp>
 
 /// Type is a gdual

--- a/include/dcgp/wrapped_functions.hpp
+++ b/include/dcgp/wrapped_functions.hpp
@@ -1,17 +1,15 @@
 #ifndef DCGP_WRAPPED_FUNCTIONS_H
 #define DCGP_WRAPPED_FUNCTIONS_H
 
-
 #include <audi/audi.hpp>
 #include <audi/functions.hpp>
 #include <cmath>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <dcgp/config.hpp>
 #include <dcgp/type_traits.hpp>
-
-using namespace audi;
 
 namespace dcgp
 {
@@ -21,9 +19,6 @@ namespace dcgp
 // double and a gdual type Complex could also be allowed.
 template <typename T>
 using f_enabler = typename std::enable_if<std::is_same<T, double>::value || is_gdual<T>::value, int>::type;
-
-// Allows to overload in templates std functions with audi functions
-using namespace audi;
 
 /*--------------------------------------------------------------------------
  *                              N-ARITY FUNCTIONS
@@ -86,7 +81,7 @@ inline std::string print_my_div(const std::vector<std::string> &in)
     return "(" + retval + ")";
 }
 
-// protected division (double overload):
+// Protected divide function (double overload):
 template <typename T, typename std::enable_if<std::is_same<T, double>::value, int>::type = 0>
 inline T my_pdiv(const std::vector<T> &in)
 {
@@ -106,17 +101,14 @@ inline T my_pdiv(const std::vector<T> &in)
     return 1.;
 }
 
-// protected division (gdual overload):
+// Protected divide function (gdual overload):
+// this will throw a compiler error when used.
+// The pdiv is only available as a double type, for use in CGP.
+// Because the gradients created when using gdual are mathematically invalid.
 template <typename T, typename std::enable_if<is_gdual<T>::value, int>::type = 0>
 inline T my_pdiv(const std::vector<T> &in)
 {
-    T retval(in[0]);
-    for (auto i = 1u; i < in.size(); ++i) {
-        if (in[i].constant_cf() == typename T::cf_type(0.)) {
-            retval /= in[i];
-        }
-    }
-    return retval;
+    throw std::invalid_argument("The protected division is not supported for gdual types.");
 }
 
 inline std::string print_my_pdiv(const std::vector<std::string> &in)

--- a/tests/compute_perf.cpp
+++ b/tests/compute_perf.cpp
@@ -1,10 +1,13 @@
 #define BOOST_TEST_MODULE dcgp_evaluation_perf
+#include <audi/audi.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/timer/timer.hpp>
 #include <iostream>
 
 #include <dcgp/expression.hpp>
 #include <dcgp/kernel_set.hpp>
+
+using gdual_d = audi::gdual_d;
 
 void perform_evaluations(unsigned int in, unsigned int out, unsigned int rows, unsigned int columns,
                          unsigned int levels_back, unsigned int arity, unsigned int N,
@@ -41,7 +44,7 @@ BOOST_AUTO_TEST_CASE(evaluation_speed)
     unsigned int N = 100000;
 
     dcgp::kernel_set<double> kernel_set1({"sum", "diff", "mul", "div"});
-    dcgp::stream(std::cout, "Function set ", kernel_set1(), "\n");
+    audi::stream(std::cout, "Function set ", kernel_set1(), "\n");
     perform_evaluations(2, 4, 2, 3, 4, 4, N, kernel_set1());
     perform_evaluations(2, 4, 10, 10, 11, 5, N, kernel_set1());
     perform_evaluations(2, 4, 20, 20, 21, 6, N, kernel_set1());
@@ -50,7 +53,7 @@ BOOST_AUTO_TEST_CASE(evaluation_speed)
     perform_evaluations(1, 1, 3, 100, 101, 9, N, kernel_set1());
 
     dcgp::kernel_set<double> kernel_set2({"sum", "mul", "sig"});
-    dcgp::stream(std::cout, "\nFunction set ", kernel_set2(), "\n");
+    audi::stream(std::cout, "\nFunction set ", kernel_set2(), "\n");
     perform_evaluations(2, 4, 2, 3, 4, 4, N, kernel_set2());
     perform_evaluations(2, 4, 10, 10, 11, 5, N, kernel_set2());
     perform_evaluations(2, 4, 20, 20, 21, 6, N, kernel_set2());

--- a/tests/differentiate_perf.cpp
+++ b/tests/differentiate_perf.cpp
@@ -1,5 +1,5 @@
 #define BOOST_TEST_MODULE dcgp_evaluation_perf
-#include <audi/gdual.hpp>
+#include <audi/audi.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/timer/timer.hpp>
 #include <iostream>
@@ -7,7 +7,7 @@
 #include <dcgp/expression.hpp>
 #include <dcgp/kernel_set.hpp>
 
-using namespace audi;
+using gdual_d = audi::gdual_d;
 
 void perform_evaluations(unsigned int in, unsigned int out, unsigned int rows, unsigned int columns,
                          unsigned int levels_back, unsigned int arity, unsigned int N,
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(evaluation_speed)
     unsigned int N = 1000;
 
     dcgp::kernel_set<gdual_d> kernel_set1({"sum", "diff", "mul", "div"});
-    dcgp::stream(std::cout, "Function set ", kernel_set1(), "\n");
+    audi::stream(std::cout, "Function set ", kernel_set1(), "\n");
     perform_evaluations(2, 4, 2, 3, 4, 2, N, kernel_set1());
     perform_evaluations(2, 4, 10, 10, 11, 2, N, kernel_set1());
     perform_evaluations(2, 4, 20, 20, 21, 2, N, kernel_set1());
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(evaluation_speed)
     perform_evaluations(1, 1, 3, 100, 101, 2, N, kernel_set1());
 
     dcgp::kernel_set<gdual_d> kernel_set2({"sum", "mul", "sig"});
-    dcgp::stream(std::cout, "Function set ", kernel_set2(), "\n");
+    audi::stream(std::cout, "Function set ", kernel_set2(), "\n");
     perform_evaluations(2, 4, 2, 3, 4, 2, N, kernel_set2());
     perform_evaluations(2, 4, 10, 10, 11, 2, N, kernel_set2());
     perform_evaluations(2, 4, 20, 20, 21, 2, N, kernel_set2());


### PR DESCRIPTION
Update tests, remove using namespace in headers to prevent filling the global scope with variables.