### PR TITLE
reduced size hessian in mes4cgp to ensure invertibility + posibility to change the loss for symbolic regression

### DIFF
--- a/dcgpy/docstrings.cpp
+++ b/dcgpy/docstrings.cpp
@@ -118,7 +118,7 @@ Computes the loss of the model on the data
 Args:
     points (2D NumPy float array or ``list of lists`` of ``float``): the input data
     labels (2D NumPy float array or ``list of lists`` of ``float``): the output labels (supervised signal)
-    loss_type (``str``): the loss, one of "MSE" for Mean Square Error and "CE" for Cross-Entropy.
+    loss (``str``): the loss type, one of "MSE" for Mean Square Error, "CE" for Cross-Entropy or "BCE" for Binary-Cross-Entropy.
 
 Raises:
     ValueError: if *points* or *labels* are malformed or if *loss_type* is not one of the available types.
@@ -1051,7 +1051,7 @@ a continuous part (i.e. the value of the parameters in the model) and an integer
 the model computational graph). The instantiated object can be used as UDP (User Defined Problem) in the pygmo optimization suite.
 
 The symbolic regression problem can be instantiated both as a single and as a two-objectives problem. In the second
-case, aside the Mean Squared Error, the model complexity will be considered as an objective.
+case, aside the choosen loss on the data, the model complexity will be considered as an objective.
 
     )";
 }
@@ -1073,6 +1073,7 @@ Args:
     n_eph (``int``): Number of ephemeral constants. 
     multi_objective (``bool``): when True the problem will be considered as multiobjective (loss and model complexity).
     parallel_batches (``int``): allows to split the data into batches for parallel evaluation.
+    loss (``int``): the loss type, one of "MSE" for Mean Square Error, "CE" for Cross-Entropy or "BCE" for Binary-Cross-Entropy.
 
 Raises:
     unspecified: any exception thrown by failures at the intersection between C++ and Python (e.g.,

--- a/dcgpy/expose_symbolic_regression.cpp
+++ b/dcgpy/expose_symbolic_regression.cpp
@@ -60,17 +60,17 @@ void expose_symbolic_regression()
              bp::make_constructor(
                  +[](const bp::object &points, const bp::object &labels, unsigned rows, unsigned cols,
                      unsigned levels_back, unsigned arity, const bp::object &kernels, unsigned n_eph,
-                     bool multi_objective, unsigned parallel_batches) {
+                     bool multi_objective, unsigned parallel_batches, const std::string loss_s) {
                      auto kernels_v = l_to_v<kernel<double>>(kernels);
                      auto vvd_points = to_vv<double>(points);
                      auto vvd_labels = to_vv<double>(labels);
                      return ::new dcgp::symbolic_regression(vvd_points, vvd_labels, rows, cols, levels_back, arity,
-                                                            kernels_v, n_eph, multi_objective, parallel_batches);
+                                                            kernels_v, n_eph, multi_objective, parallel_batches, loss_s);
                  },
                  bp::default_call_policies(),
                  (bp::arg("points"), bp::arg("labels"), bp::arg("rows") = 1, bp::arg("cols") = 16,
                   bp::arg("levels_back") = 17, bp::arg("arity") = 2, bp::arg("kernels"), bp::arg("n_eph") = 0u,
-                  bp::arg("multi_objective") = false, bp::arg("parallel_batches") = 0u)),
+                  bp::arg("multi_objective") = false, bp::arg("parallel_batches") = 0u, bp::arg("loss") = "MSE")),
              symbolic_regression_init_doc().c_str())
         .def(
             "pretty", +[](const dcgp::symbolic_regression &instance,


### PR DESCRIPTION
This pull request:

- adds an additional loss type to expressions, the binary cross entropy, I implemented a slightly different version as usually used: I require two targets per point instead of a one-hot encoded vector, the two targets can be used as the number of times a point belongs to a certain class/reached a certain state, which enables the modeling/prediction of stochastic outcomes. The version I implemented reduces to the usual binary cross entropy if every point can only belong to one class once.

- enables the selection of the loss when doing symbolic regression [by adding an additional parameter to the symbolic regression construction, which is the passed to the underlying expression when calculating the loss]

- modifies the mes4cgp algorithm to work reliably with more than 1 ephemeral constant by constructing a reduced size Hessian in the space of the active ephemeral constants. In addition I added a check that the Hessian is positive definite to ensure that the Newton step approaches a minimum (and no saddle point).

Please let me know if this goes in the direction you had in mind when writing the to-do with the invertible Hessian and/or if I can improve the pull request.
Since this is a large pull request with many additions, please feel also free to tell me that you accept only parts of it, I will then create a new request containing a subset of the proposed changes.
