### PR TITLE
expression_weighted.get_weight() and expression_weighted.set_weight() now use the correct input_id

### DIFF
--- a/include/dcgp/expression.hpp
+++ b/include/dcgp/expression.hpp
@@ -871,7 +871,7 @@ protected:
      *
      * @param[node_id] chromosome
      */
-    unsigned _get_arity(unsigned node_id) const
+    unsigned _get_arity(typename std::vector<T>::size_type node_id) const
     {
         assert(node_id >= m_n && node_id < m_n + m_r * m_c);
         unsigned col = (node_id - m_n) / m_r;

--- a/include/dcgp/expression.hpp
+++ b/include/dcgp/expression.hpp
@@ -871,7 +871,7 @@ protected:
      *
      * @param[node_id] chromosome
      */
-    unsigned _get_arity(typename std::vector<T>::size_type node_id) const
+    unsigned _get_arity(unsigned node_id) const
     {
         assert(node_id >= m_n && node_id < m_n + m_r * m_c);
         unsigned col = (node_id - m_n) / m_r;

--- a/include/dcgp/expression_weighted.hpp
+++ b/include/dcgp/expression_weighted.hpp
@@ -245,7 +245,7 @@ public:
      *
      * @throws std::invalid_argument if the node_id or input_id are not valid
      */
-    void set_weight(typename std::vector<T>::size_type node_id, typename std::vector<T>::size_type input_id, const T &w)
+    void set_weight(unsigned node_id, unsigned input_id, const T &w)
     {
         if (node_id < this->get_n() || node_id >= this->get_n() + this->get_r() * this->get_c()) {
             throw std::invalid_argument("Requested node id does not exist");
@@ -286,7 +286,7 @@ public:
      *
      * @throws std::invalid_argument if the node_id or input_id are not valid
      */
-    T get_weight(typename std::vector<T>::size_type node_id, typename std::vector<T>::size_type input_id) const
+    T get_weight(unsigned node_id, unsigned input_id) const
     {
         if (node_id < this->get_n() || node_id >= this->get_n() + this->get_r() * this->get_c()) {
             throw std::invalid_argument(

--- a/include/dcgp/expression_weighted.hpp
+++ b/include/dcgp/expression_weighted.hpp
@@ -255,7 +255,7 @@ public:
         }
         // index of the node in the weight vector
         auto idx = this->get_gene_idx()[node_id] - (node_id - this->get_n());
-        m_weights[idx] = w;
+        m_weights[idx + input_id] = w;
     }
 
     /// Sets all weights
@@ -297,7 +297,7 @@ public:
         }
 
         auto idx = this->get_gene_idx()[node_id] - (node_id - this->get_n());
-        return m_weights[idx];
+        return m_weights[idx + input_id];
     }
 
     /// Gets the weights

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ ENDMACRO(ADD_DCGP_TESTCASE)
 
 ADD_DCGP_TESTCASE(expression)
 ADD_DCGP_TESTCASE(differentiate)
+ADD_DCGP_TESTCASE(expression_weighted)
 ADD_DCGP_TESTCASE(expression_ann)
 ADD_DCGP_TESTCASE(kernel)
 ADD_DCGP_TESTCASE(function)

--- a/test/expression_weighted.cpp
+++ b/test/expression_weighted.cpp
@@ -1,0 +1,38 @@
+#define BOOST_TEST_MODULE dcgp_expression_weighted_test
+#include <boost/test/included/unit_test.hpp>
+
+#include <dcgp/expression_weighted.hpp>
+#include <dcgp/kernel_set.hpp>
+
+#include "helpers.hpp"
+
+using namespace dcgp;
+
+
+BOOST_AUTO_TEST_CASE(get_set_weight_test)
+{
+    kernel_set<double> basic_set({"sum", "diff", "mul", "div"});
+    std::vector<unsigned> arity{3, 2, 1};
+    expression_weighted<double> ex(1, 1, 2, 3, 4, arity, basic_set(), 0u);
+    // we use the float of the input_id as weight
+    std::vector<double> weights{0., 1., 2., 0., 1., 2., 0., 1., 0., 1., 0., 0.};
+    ex.set_weights(weights);
+    // check getting single weights
+    BOOST_CHECK(ex.get_weight(1u, 0u) == 0.);
+    BOOST_CHECK(ex.get_weight(1u, 1u) == 1.);
+    BOOST_CHECK(ex.get_weight(1u, 2u) == 2.);
+    // skip check for node 2 and 3, 2 is same as 1; 3 is same as 4
+    BOOST_CHECK(ex.get_weight(4u, 0u) == 0.);
+    BOOST_CHECK(ex.get_weight(4u, 1u) == 1.);
+    // check node 5 and 6 (they are the same)
+    BOOST_CHECK(ex.get_weight(5u, 0u) == 0.);
+    BOOST_CHECK(ex.get_weight(6u, 0u) == 0.);
+    // change single weights in expression and reference weights
+    ex.set_weight(1u, 0u, 10.);
+    weights[0] = 10.;
+    ex.set_weight(4u, 1u, 10.);
+    // position in reference weights is r*arity(c_1) + r*arity(c_2) = 10
+    weights[9] = 10.;
+    // check all weights together
+    CHECK_CLOSE_V(ex.get_weights(), weights, 1e-12);
+}


### PR DESCRIPTION
fixes #56 .
I added test for expression_weighted<double> for all four methods that get/set weights (both single weights and the whole vector).