### PR TITLE
more control for finegrained threading

### DIFF
--- a/dcgpy/core.cpp
+++ b/dcgpy/core.cpp
@@ -4,12 +4,22 @@
 
 #include <dcgp/problems/symbolic_regression.hpp>
 
+#include <boost/optional.hpp>
+
+#include <tbb/global_control.h>
+
+#include "docstrings.hpp"
 #include "expose_expressions.hpp"
 #include "expose_kernels.hpp"
 #include "expose_symbolic_regression.hpp"
 
+
 using namespace dcgpy;
 namespace py = pybind11;
+
+namespace {
+    boost::optional<tbb::global_control> thread_control; 
+}
 
 PYBIND11_MODULE(core, m)
 {
@@ -34,4 +44,8 @@ PYBIND11_MODULE(core, m)
         }
         return retval;
     };
+
+    m.def("disable_threading", [](){ thread_control.emplace(tbb::global_control::max_allowed_parallelism, 1); }, disable_threading_doc().c_str());
+    m.def("enable_threading", [](){ thread_control.reset(); }, enable_threading_doc().c_str());
+
 } // namespace details

--- a/dcgpy/docstrings.cpp
+++ b/dcgpy/docstrings.cpp
@@ -5,6 +5,36 @@
 namespace dcgpy
 {
 
+std::string disable_threading_doc()
+{
+    return R"(disable_threading()
+
+Disables threading on a global level.
+
+Example:
+
+>>> from dcgpy import *
+>>> disable_threading()
+)";
+}
+
+
+std::string enable_threading_doc()
+{
+    return R"(enable_threading()
+
+Enables threading on a global level (if disabled by calling :func:`dcgpy.disable_threading`).
+
+Example:
+
+>>> from dcgpy import *
+>>> disable_threading()
+>>> enable_threading()
+)";
+}
+
+
+
 std::string kernel_init_doc(const std::string &type)
 {
     return R"(kernel_)"

--- a/dcgpy/docstrings.hpp
+++ b/dcgpy/docstrings.hpp
@@ -5,6 +5,10 @@
 
 namespace dcgpy
 {
+// utilities
+std::string disable_threading_doc();
+std::string enable_threading_doc();
+	
 // kernel set
 std::string kernel_init_doc(const std::string &);
 std::string kernel_set_init_doc(const std::string &);

--- a/dcgpy/test.py
+++ b/dcgpy/test.py
@@ -365,6 +365,10 @@ class test_es4cgp(_ut.TestCase):
         from dcgpy import symbolic_regression, generate_koza_quintic, kernel_set_double, es4cgp
         import pygmo as pg
         import pickle
+        # bypass issues appearing on large servers (OSError: Too many files open)
+        pg.mp_island.resize_pool(4)
+        pg.mp_bfe.resize_pool(4)
+
         X, Y = generate_koza_quintic()
         # Interface for the UDPs
         udp = symbolic_regression(
@@ -391,7 +395,8 @@ class test_es4cgp(_ut.TestCase):
         archi.evolve()
         archi.wait_check()
         # In parallel via bfe
-        uda.set_bfe(pg.bfe(pg.mp_bfe()))
+        bfe = pg.mp_bfe()
+        uda.set_bfe(pg.bfe(bfe))
         pop = uda.evolve(pop)
         self.assertTrue(repr(algo) == repr(pickle.loads(pickle.dumps(algo))))
 
@@ -400,6 +405,10 @@ class test_moes4cgp(_ut.TestCase):
         from dcgpy import symbolic_regression, generate_koza_quintic, kernel_set_double, moes4cgp
         import pygmo as pg
         import pickle
+        # bypass issues appearing on large servers (OSError: Too many files open)
+        pg.mp_island.resize_pool(4)
+        pg.mp_bfe.resize_pool(4)
+
         X, Y = generate_koza_quintic()
         # Interface for the UDPs
         udp = symbolic_regression(
@@ -436,6 +445,10 @@ class test_mes4cgp(_ut.TestCase):
         from dcgpy import symbolic_regression, generate_koza_quintic, kernel_set_double, mes4cgp
         import pygmo as pg
         import pickle
+        # bypass issues appearing on large servers (OSError: Too many files open)
+        pg.mp_island.resize_pool(4)
+        pg.mp_bfe.resize_pool(4)
+     
         X, Y = generate_koza_quintic()
         # Interface for the UDPs
         udp = symbolic_regression(
@@ -469,6 +482,10 @@ class test_momes4cgp(_ut.TestCase):
         from dcgpy import symbolic_regression, generate_koza_quintic, kernel_set_double, momes4cgp
         import pygmo as pg
         import pickle
+        # bypass issues appearing on large servers (OSError: Too many files open)
+        pg.mp_island.resize_pool(4)
+        pg.mp_bfe.resize_pool(4)
+  
         X, Y = generate_koza_quintic()
         # Interface for the UDPs
         udp = symbolic_regression(

--- a/dcgpy/test.py
+++ b/dcgpy/test.py
@@ -548,7 +548,13 @@ class test_gd4cgp(_ut.TestCase):
         # Pickling.
         self.assertTrue(repr(algo) == repr(pickle.loads(pickle.dumps(algo))))
 
+class test_global_threading(_ut.TestCase):
+    def runTest(self):
+        from dcgpy import disable_threading, enable_threading
+        disable_threading()
+        enable_threading()
 
+ 
 def run_test_suite():
     """Run the full test suite.
     This function will raise an exception if at least one test fails.
@@ -563,6 +569,7 @@ def run_test_suite():
     suite.addTest(test_mes4cgp())
     suite.addTest(test_momes4cgp())
     suite.addTest(test_gd4cgp())
+    suite.addTest(test_global_threading())
 
     test_result = _ut.TextTestRunner(verbosity=2).run(suite)
     if len(test_result.failures) > 0 or len(test_result.errors) > 0:

--- a/doc/sphinx/docs/python/index.rst
+++ b/doc/sphinx/docs/python/index.rst
@@ -3,7 +3,16 @@
 Python Documentation
 ====================
 
-.. contents::
+Utilities
+---------
+
+Assorted functionalities.
+
+.. toctree::
+   :maxdepth: 1
+
+   threading
+
 
 Kernels
 ---------

--- a/doc/sphinx/docs/python/threading.rst
+++ b/doc/sphinx/docs/python/threading.rst
@@ -1,0 +1,13 @@
+Threading
+---------
+
+disable_threading
+^^^^^^^^^^^^^^^^^
+
+.. autofunction:: dcgpy.disable_threading
+
+enable_threading
+^^^^^^^^^^^^^^^^^
+
+.. autofunction:: dcgpy.enable_threading
+

--- a/include/dcgp/algorithms/mes4cgp.hpp
+++ b/include/dcgp/algorithms/mes4cgp.hpp
@@ -13,6 +13,8 @@
 #include <tuple>
 #include <vector>
 
+#include <tbb/global_control.h>
+
 #include <dcgp/problems/symbolic_regression.hpp>
 #include <dcgp/rng.hpp>
 #include <dcgp/s11n.hpp>
@@ -78,6 +80,7 @@ public:
         if (ftol < 0.) {
             throw std::invalid_argument("The ftol is negative, it must be positive or zero.");
         }
+
     }
 
     /// Algorithm evolve method
@@ -92,7 +95,10 @@ public:
      */
     pagmo::population evolve(pagmo::population pop) const
     {
-        const auto &prob = pop.get_problem();
+        // workaround to disable threading 
+	tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
+	
+	const auto &prob = pop.get_problem();
         auto n_obj = prob.get_nobj();
         const auto bounds = prob.get_bounds();
         auto NP = pop.size();

--- a/include/dcgp/algorithms/mes4cgp.hpp
+++ b/include/dcgp/algorithms/mes4cgp.hpp
@@ -13,8 +13,6 @@
 #include <tuple>
 #include <vector>
 
-#include <tbb/global_control.h>
-
 #include <dcgp/problems/symbolic_regression.hpp>
 #include <dcgp/rng.hpp>
 #include <dcgp/s11n.hpp>
@@ -95,9 +93,6 @@ public:
      */
     pagmo::population evolve(pagmo::population pop) const
     {
-        // workaround to disable threading 
-	tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
-	
 	const auto &prob = pop.get_problem();
         auto n_obj = prob.get_nobj();
         const auto bounds = prob.get_bounds();

--- a/include/dcgp/algorithms/momes4cgp.hpp
+++ b/include/dcgp/algorithms/momes4cgp.hpp
@@ -13,8 +13,6 @@
 #include <tuple>
 #include <vector>
 
-#include <tbb/global_control.h>
-
 #include <dcgp/problems/symbolic_regression.hpp>
 #include <dcgp/rng.hpp>
 #include <dcgp/s11n.hpp>
@@ -90,9 +88,6 @@ public:
      */
     pagmo::population evolve(pagmo::population pop) const
     {
-        // workaround to avoid unwanted threading
-        tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
-	
 	const auto &prob = pop.get_problem();
         auto n_obj = prob.get_nobj();
         const auto bounds = prob.get_bounds();

--- a/include/dcgp/algorithms/momes4cgp.hpp
+++ b/include/dcgp/algorithms/momes4cgp.hpp
@@ -13,6 +13,8 @@
 #include <tuple>
 #include <vector>
 
+#include <tbb/global_control.h>
+
 #include <dcgp/problems/symbolic_regression.hpp>
 #include <dcgp/rng.hpp>
 #include <dcgp/s11n.hpp>
@@ -88,7 +90,10 @@ public:
      */
     pagmo::population evolve(pagmo::population pop) const
     {
-        const auto &prob = pop.get_problem();
+        // workaround to avoid unwanted threading
+        tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
+	
+	const auto &prob = pop.get_problem();
         auto n_obj = prob.get_nobj();
         const auto bounds = prob.get_bounds();
         auto NP = pop.size();


### PR DESCRIPTION
This PR introduces in the Python module the possibility to disable or re-enable threading by the corresponding functions:

```
dcgpy.disable_threading()
```
and
```
dcgpy.enable_threading()
```

- [x] implement pybind11 wrappers to tbb-equivalent
- [x] write test for python module
- [x] write docs
